### PR TITLE
Telephony: only add vmail sim slot indicator with multi sim

### DIFF
--- a/src/com/android/phone/NotificationMgr.java
+++ b/src/com/android/phone/NotificationMgr.java
@@ -45,6 +45,8 @@ import android.telephony.ServiceState;
 import android.text.SpannableStringBuilder;
 import android.text.format.DateUtils;
 import android.text.style.RelativeSizeSpan;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
@@ -295,7 +297,7 @@ public class NotificationMgr {
         int notificationId = getNotificationId(VOICEMAIL_NOTIFICATION, phoneId);
         if (visible) {
             int resId = android.R.drawable.stat_notify_voicemail;
-            if (PhoneUtils.isMultiSimEnabled()) {
+            if (showSimSlotIcon()) {
                 resId = mwiIcon[phoneId];
             }
 
@@ -419,6 +421,15 @@ public class NotificationMgr {
             mNotificationManager.cancelAsUser(
                     null /* tag */, notificationId, UserHandle.ALL);
         }
+    }
+
+    private boolean showSimSlotIcon() {
+        final List<SubscriptionInfo> subInfoList =
+                SubscriptionManager.from(mContext).getActiveSubscriptionInfoList();
+        if (subInfoList == null) {
+            return false;
+        }
+        return subInfoList.size() > 1;
     }
 
     /**


### PR DESCRIPTION
The check on whether to use the icon to indicate which SIM slot the
voicemail is for was checking for number of SIM slots, not active SIMs.

Only add the icon when there is more than one SIM in the device.

Ref: PAELLA-96

Change-Id: I7adb35f17b146bade92ba7e447ab17419bd4f2d0
Signed-off-by: Roman Birg <roman@cyngn.com>